### PR TITLE
fix: Add `belongsTo` edge and expand group

### DIFF
--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/EdgeBuilder.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/EdgeBuilder.java
@@ -77,4 +77,8 @@ public class EdgeBuilder {
 	public Edge diagnostic(Vertex from, Vertex to) {
 		return new Edge(generator.next(), Edge.T_DIAGNOSTIC, from.getId(), to.getId());
 	}
+
+	public Edge belongsTo(Vertex from, Vertex to) {
+		return new Edge(generator.next(), Edge.BELONGSTO, from.getId(), to.getId());
+	}
 }

--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
@@ -99,10 +99,11 @@ public class Indexer {
 
 		final ExecutorService threadPool = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
-		Group groupVertex = lsif.getVertexBuilder().group(ResourceUtils.fixURI(path.toFile().toURI()), ConflictResolution.TAKEDB, path.lastSegment(), ResourceUtils.fixURI(path.toFile().toURI()));
-			LsifEmitter.getInstance().emit(groupVertex);
+		Group groupVertex = lsif.getVertexBuilder().group(ResourceUtils.fixURI(path.toFile().toURI()),
+				ConflictResolution.TAKEDB, path.lastSegment(), ResourceUtils.fixURI(path.toFile().toURI()));
+		LsifEmitter.getInstance().emit(groupVertex);
 		LsifEmitter.getInstance().emit(
-			lsif.getVertexBuilder().event(Event.EventScope.Group, Event.EventKind.BEGIN, groupVertex.getId()));
+				lsif.getVertexBuilder().event(Event.EventScope.Group, Event.EventKind.BEGIN, groupVertex.getId()));
 
 		for (IProject proj : projects) {
 			if (proj == null) {
@@ -122,7 +123,6 @@ public class Indexer {
 				JavaLanguageServerPlugin.logException(e.getMessage(), e);
 			}
 
-
 			Project projVertex = lsif.getVertexBuilder().project(javaProject.getElementName());
 			LsifEmitter.getInstance().emit(projVertex);
 			LsifEmitter.getInstance().emit(
@@ -139,8 +139,8 @@ public class Indexer {
 
 		}
 
-		LsifEmitter.getInstance().emit(
-					lsif.getVertexBuilder().event(Event.EventScope.Group, Event.EventKind.END, groupVertex.getId()));
+		LsifEmitter.getInstance()
+				.emit(lsif.getVertexBuilder().event(Event.EventScope.Group, Event.EventKind.END, groupVertex.getId()));
 
 		threadPool.shutdown();
 	}

--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
@@ -136,7 +136,6 @@ public class Indexer {
 			VisitorUtils.endAllDocument(lsif);
 			LsifEmitter.getInstance().emit(
 					lsif.getVertexBuilder().event(Event.EventScope.Project, Event.EventKind.END, projVertex.getId()));
-
 		}
 
 		LsifEmitter.getInstance()

--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/protocol/Edge.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/protocol/Edge.java
@@ -45,6 +45,8 @@ public class Edge extends Element {
 
 	public final static String PACKAGEINFORMATION = "packageInformation";
 
+	public final static String BELONGSTO = "belongsTo";
+
 	private String outV;
 
 	private String inV;


### PR DESCRIPTION
As a part of update to LSIF v0.5.0, this PR fixes two things:
1. Add a `belongsTo` edge to connect the project vertex and its group vertex.
2. Expand the group to include all the projects in a directory.