### PR TITLE
chore: update target platform

### DIFF
--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/indexer/Indexer.java
@@ -49,6 +49,9 @@ import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.GradleProjectImporter;
 import org.eclipse.jdt.ls.core.internal.managers.MavenProjectImporter;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DocumentSymbolCapabilities;
+import org.eclipse.lsp4j.SymbolKindCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.gradle.tooling.model.GradleModuleVersion;
 import org.gradle.tooling.model.gradle.GradlePublication;
 import org.gradle.tooling.model.gradle.ProjectPublications;
@@ -158,7 +161,13 @@ public class Indexer {
 	private void initializeJdtls() {
 		Map<String, Object> extendedClientCapabilities = new HashMap<>();
 		extendedClientCapabilities.put("classFileContentsSupport", false);
-		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(new ClientCapabilities(),
+		DocumentSymbolCapabilities documentSymbol = new DocumentSymbolCapabilities(new SymbolKindCapabilities(),
+			/** dynamicRegistration */ false, /** hierarchicalDocumentSymbolSupport */ true);
+		TextDocumentClientCapabilities textDocument = new TextDocumentClientCapabilities();
+		textDocument.setDocumentSymbol(documentSymbol);
+		ClientCapabilities clientCapabilities = new ClientCapabilities();
+		clientCapabilities.setTextDocument(textDocument);
+		JavaLanguageServerPlugin.getPreferencesManager().updateClientPrefences(clientCapabilities,
 				extendedClientCapabilities);
 	}
 

--- a/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/visitors/DocumentVisitor.java
+++ b/com.microsoft.java.lsif.core/src/com/microsoft/java/lsif/core/internal/visitors/DocumentVisitor.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.handlers.DocumentSymbolHandler;
 import org.eclipse.lsp4j.DocumentSymbol;
@@ -60,7 +61,7 @@ public class DocumentVisitor extends ProtocolVisitor {
 
 	private List<DocumentSymbol> handle(String uri) {
 		DocumentSymbolParams documentSymbolParams = new DocumentSymbolParams(new TextDocumentIdentifier(uri));
-		DocumentSymbolHandler proxy = new DocumentSymbolHandler(true);
+		DocumentSymbolHandler proxy = new DocumentSymbolHandler(JavaLanguageServerPlugin.getPreferencesManager());
 		List<Either<SymbolInformation, DocumentSymbol>> result = proxy.documentSymbol(documentSymbolParams,
 				new NullProgressMonitor());
 

--- a/com.microsoft.java.lsif.target/com.microsoft.java.lsif.tp.target
+++ b/com.microsoft.java.lsif.target/com.microsoft.java.lsif.tp.target
@@ -19,7 +19,7 @@
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/technology/m2e/milestones/1.17/1.17.0.20201112-0751/"/>
+            <repository location="https://download.eclipse.org/technology/m2e/releases/1.18.2/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.equinox.core.feature.feature.group" version="0.0.0"/>
@@ -43,7 +43,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/0.71.0.202103161929/"/>
+            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.7.0.202112042131/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>


### PR DESCRIPTION
replace some outdated links.

Since jdtls 1.2, the constructor `DocumentSymbolHandler(boolean)` is replaced by `DocumentSymbolHandler(PreferencesManager)`, so I assign `hierarchicalDocumentSymbolSupport` to true in the initializing stage and get the PreferencesManager from JavaLanguageServerPlugin later.
