### PR TITLE
chore: Update dependencies

### DIFF
--- a/cmd/package-lock.json
+++ b/cmd/package-lock.json
@@ -20,9 +20,9 @@
       }
     },
     "fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",

--- a/cmd/package.json
+++ b/cmd/package.json
@@ -12,7 +12,7 @@
   "author": "yaozheng@microsoft.com, sheche@microsoft.com",
   "license": "ISC",
   "devDependencies": {
-    "fs-extra": "^10.1.0",
+    "fs-extra": "^11.1.0",
     "glob": "^8.0.3"
   }
 }

--- a/com.microsoft.java.lsif.target/com.microsoft.java.lsif.tp.target
+++ b/com.microsoft.java.lsif.target/com.microsoft.java.lsif.tp.target
@@ -13,7 +13,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/buildship/updates/e423/releases/3.x/3.1.6.v20220511-1359/"/>
+            <repository location="https://download.eclipse.org/buildship/updates/e423/snapshots/3.x/3.1.7.v20221108-1729-s/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
@@ -41,7 +41,7 @@
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.18.0.202211021915/"/>
+            <repository location="https://download.eclipse.org/jdtls/snapshots/repository/1.18.0.202211291837/"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>


### PR DESCRIPTION
@jdneo Could you help update the node version of pipelines in Azure DevOps? new `fs-extra` requires node 14.14+:https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md#1100--2022-11-28